### PR TITLE
fix links in 'Recent Posts' section

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -18,7 +18,7 @@
             {% for post in site.posts limit:4 %}
                 <li>
                     <a href="{{ post.url  | prepend: site.baseurl }}">
-                    <p><a href="{{ post.url }}">{{ post.title }}</a></p>
+                    <p><a href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a></p>
                 <em>Posted on {{ post.date | date_to_string }}</em>
             </li>
             {% endfor %}


### PR DESCRIPTION
Sorry, I don't have an easy way to test this fix.
But the links are currently giving me 404's.