### PR TITLE
fastqtools main and sub commands usage

### DIFF
--- a/_apps/bioinformatics/bioinformatics-fastqtools.md
+++ b/_apps/bioinformatics/bioinformatics-fastqtools.md
@@ -20,15 +20,15 @@ files:
 %appinstall bioinformatics-fastqtools
     apt-get -y install wget
     apt-get -y install autoconf libtool build-essential
-    apt-get -y install libpcre3-dev
-    apt-get -y install zlibc libz-dev
     apt-get -y install libpcre3 libpcre3-dev
-    wget  https://github.com/dcjones/fastq-tools/archive/v0.8.tar.gz -O fastq-tools-0.8.tar.gz
+    apt-get -y install zlibc libz-dev
+    apt-get clean
+    wget https://github.com/dcjones/fastq-tools/archive/v0.8.tar.gz -O fastq-tools-0.8.tar.gz
     tar --extract --gzip --file fastq-tools-0.8.tar.gz
     rm fastq-tools-0.8.tar.gz
     cd fastq-tools-0.8
     ./autogen.sh && ./configure && make
-    cd -
+    cd ..
     cp  fastq-tools-0.8/src/fastq-grep    bin/
     cp  fastq-tools-0.8/src/fastq-kmers   bin/
     cp  fastq-tools-0.8/src/fastq-match   bin/
@@ -42,7 +42,7 @@ files:
 %appfiles bioinformatics-fastqtools
     fastqtools bin/
 %appenv bioinformatics-fastqtools
-    FASTQTOOLS_HOME="/scif/apps/bioinformatics-fastqtools"
+    FASTQTOOLS_HOME=/scif/apps/bioinformatics-fastqtools
     export FASTQTOOLS_HOME
 %apphelp bioinformatics-fastqtools
     fastq-tools provide a number of small and efficient programs to perform common tasks
@@ -52,7 +52,7 @@ files:
     exec /bin/bash fastqtools "$@"
 %applabels bioinformatics-fastqtools
     MAINTAINER adomissy@ucsd.edu
-    VERSION 0.0.1
-    WRAPPEDTOOL_VERSION: 0.8
-    WRAPPEDTOOL_INFO: "https://homes.cs.washington.edu/~dcjones/fastq-tools/"
+    BUILD_VERSION 0.0.1
+    WRAPPEDTOOL_VERSION 0.8
+    WRAPPEDTOOL_INFO https://homes.cs.washington.edu/~dcjones/fastq-tools/
 ```

--- a/_apps/bioinformatics/bioinformatics-fastqtools.md
+++ b/_apps/bioinformatics/bioinformatics-fastqtools.md
@@ -29,14 +29,14 @@ files:
     cd fastq-tools-0.8
     ./autogen.sh && ./configure && make
     cd ..
-    cp  fastq-tools-0.8/src/fastq-grep    bin/
-    cp  fastq-tools-0.8/src/fastq-kmers   bin/
-    cp  fastq-tools-0.8/src/fastq-match   bin/
-    cp  fastq-tools-0.8/src/fastq-uniq    bin/
-    cp  fastq-tools-0.8/src/fastq-qual    bin/
-    cp  fastq-tools-0.8/src/fastq-sample  bin/
-    cp  fastq-tools-0.8/src/fastq-qualadj bin/
-    cp  fastq-tools-0.8/src/fastq-qscale  bin/
+    cp  fastq-tools-0.8/src/fastq-grep    bin/grep
+    cp  fastq-tools-0.8/src/fastq-kmers   bin/kmers
+    cp  fastq-tools-0.8/src/fastq-match   bin/match
+    cp  fastq-tools-0.8/src/fastq-uniq    bin/uniq
+    cp  fastq-tools-0.8/src/fastq-qual    bin/qual
+    cp  fastq-tools-0.8/src/fastq-sample  bin/sample
+    cp  fastq-tools-0.8/src/fastq-qualadj bin/qualadj
+    cp  fastq-tools-0.8/src/fastq-qscale  bin/qscale
     chmod u+x bin/*
     rm -rf fastq-tools-0.8
 %appfiles bioinformatics-fastqtools
@@ -48,6 +48,10 @@ files:
     fastq-tools provide a number of small and efficient programs to perform common tasks
     with high throughput sequencing data in the FASTQ format.
     All of the programs work with typical FASTQ files as well as gzipped FASTQ files.
+    It is recommended to create the following alias:
+    alias fastqtools="singularity run --app bioinformatics-fastqtools \${SINGULARITY_CONTAINER}"
+    More help is then available by running
+    fastqtools --help
 %apprun bioinformatics-fastqtools
     exec /bin/bash fastqtools "$@"
 %applabels bioinformatics-fastqtools

--- a/_apps/bioinformatics/bioinformatics-fastqtools/SingularityApp.fastqtools
+++ b/_apps/bioinformatics/bioinformatics-fastqtools/SingularityApp.fastqtools
@@ -10,14 +10,14 @@
     cd fastq-tools-0.8
     ./autogen.sh && ./configure && make
     cd ..
-    cp  fastq-tools-0.8/src/fastq-grep    bin/
-    cp  fastq-tools-0.8/src/fastq-kmers   bin/
-    cp  fastq-tools-0.8/src/fastq-match   bin/
-    cp  fastq-tools-0.8/src/fastq-uniq    bin/
-    cp  fastq-tools-0.8/src/fastq-qual    bin/
-    cp  fastq-tools-0.8/src/fastq-sample  bin/
-    cp  fastq-tools-0.8/src/fastq-qualadj bin/
-    cp  fastq-tools-0.8/src/fastq-qscale  bin/
+    cp  fastq-tools-0.8/src/fastq-grep    bin/grep
+    cp  fastq-tools-0.8/src/fastq-kmers   bin/kmers
+    cp  fastq-tools-0.8/src/fastq-match   bin/match
+    cp  fastq-tools-0.8/src/fastq-uniq    bin/uniq
+    cp  fastq-tools-0.8/src/fastq-qual    bin/qual
+    cp  fastq-tools-0.8/src/fastq-sample  bin/sample
+    cp  fastq-tools-0.8/src/fastq-qualadj bin/qualadj
+    cp  fastq-tools-0.8/src/fastq-qscale  bin/qscale
     chmod u+x bin/*
     rm -rf fastq-tools-0.8
 %appfiles bioinformatics-fastqtools
@@ -29,6 +29,10 @@
     fastq-tools provide a number of small and efficient programs to perform common tasks
     with high throughput sequencing data in the FASTQ format.
     All of the programs work with typical FASTQ files as well as gzipped FASTQ files.
+    It is recommended to create the following alias:
+    alias fastqtools="singularity run --app bioinformatics-fastqtools \${SINGULARITY_CONTAINER}"
+    More help is then available by running
+    fastqtools --help
 %apprun bioinformatics-fastqtools
     exec /bin/bash fastqtools "$@"
 %applabels bioinformatics-fastqtools

--- a/_apps/bioinformatics/bioinformatics-fastqtools/SingularityApp.fastqtools
+++ b/_apps/bioinformatics/bioinformatics-fastqtools/SingularityApp.fastqtools
@@ -1,15 +1,15 @@
 %appinstall bioinformatics-fastqtools
     apt-get -y install wget
     apt-get -y install autoconf libtool build-essential
-    apt-get -y install libpcre3-dev
     apt-get -y install libpcre3 libpcre3-dev
     apt-get -y install zlibc libz-dev
-    wget  https://github.com/dcjones/fastq-tools/archive/v0.8.tar.gz -O fastq-tools-0.8.tar.gz
+    apt-get clean
+    wget https://github.com/dcjones/fastq-tools/archive/v0.8.tar.gz -O fastq-tools-0.8.tar.gz
     tar --extract --gzip --file fastq-tools-0.8.tar.gz
     rm fastq-tools-0.8.tar.gz
     cd fastq-tools-0.8
     ./autogen.sh && ./configure && make
-    cd -
+    cd ..
     cp  fastq-tools-0.8/src/fastq-grep    bin/
     cp  fastq-tools-0.8/src/fastq-kmers   bin/
     cp  fastq-tools-0.8/src/fastq-match   bin/
@@ -32,7 +32,7 @@
 %apprun bioinformatics-fastqtools
     exec /bin/bash fastqtools "$@"
 %applabels bioinformatics-fastqtools
-  MAINTAINER adomissy@ucsd.edu
-  VERSION 0.0.1
-  WRAPPEDTOOL_VERSION: 0.8
-  WRAPPEDTOOL_INFO: "http://www.htslib.org/"
+    MAINTAINER adomissy@ucsd.edu
+    BUILD_VERSION 0.0.1
+    WRAPPEDTOOL_VERSION 0.8
+    WRAPPEDTOOL_INFO https://homes.cs.washington.edu/~dcjones/fastq-tools/

--- a/_apps/bioinformatics/bioinformatics-fastqtools/fastqtools
+++ b/_apps/bioinformatics/bioinformatics-fastqtools/fastqtools
@@ -1,11 +1,19 @@
 #!/usr/bin/env bash
 
-echo fastqtools v0.8
-echo ===============
-echo the following commands are available:
-ls -1 ${FASTQTOOLS_HOME}/bin
-echo
+if [[ -n ${1} ]]
+then
 
-echo "Usage:"
-echo "singularity exec --app bioinformatics-fastqtools <container> <command>"
-echo
+    exec ${@}
+
+else
+
+    echo fastqtools v0.8
+    echo ===============
+    echo the following commands are available:
+    ls -1 ${FASTQTOOLS_HOME}/bin
+    echo
+    echo "Usage:"
+    echo "singularity run --app bioinformatics-fastqtools ${SINGULARITY_CONTAINER} <command>"
+    echo
+
+fi

--- a/_apps/bioinformatics/bioinformatics-fastqtools/fastqtools
+++ b/_apps/bioinformatics/bioinformatics-fastqtools/fastqtools
@@ -3,30 +3,33 @@
 if [[ -n ${1} ]]
 then
 
-    exec ${@}
-
+    if [[ -n ${2} ]]
+    then
+        exec ${@}
+    else
+        exec ${1} --help
+    fi
 else
 
     echo
-    echo Program: fastqtools v0.8 (Tools for high throughput sequencing data in the FASTQ format)
-    echo Version: 0.8
+    echo "Program: fastqtools v0.8 (Tools for high throughput sequencing data in the FASTQ format)"
+    echo "Version: 0.8"
     echo
-    echo Usage: singularity run --app bioinformatics-fastqtools ${SINGULARITY_CONTAINER} <command>
+    echo "Usage: singularity run --app bioinformatics-fastqtools ${SINGULARITY_CONTAINER} <command>"
     echo
-    echo OR
-    echo        provided the fastqtools alias is defined as below:
-    echo        alias fastqtools="singularity run --app bioinformatics-fastqtools ${SINGULARITY_CONTAINER}"
+    echo "OR,   provided this alias is defined:"
+    echo "      alias fastqtools='singularity run --app bioinformatics-fastqtools ${SINGULARITY_CONTAINER}'"
     echo
-    echo Usage: fastqtools <command>
+    echo "Usage: fastqtools <command>"
     echo
-    echo Commands:
-    echo     kmers
-    echo     match
-    echo     uniq
-    echo     qual
-    echo     sample
-    echo     qualaj
-    echo     qscale
+    echo "Commands:"
+    echo "    kmers"
+    echo "    match"
+    echo "    uniq"
+    echo "    qual"
+    echo "    sample"
+    echo "    qualadj"
+    echo "    qscale"
     echo
 
 fi

--- a/_apps/bioinformatics/bioinformatics-fastqtools/fastqtools
+++ b/_apps/bioinformatics/bioinformatics-fastqtools/fastqtools
@@ -7,13 +7,26 @@ then
 
 else
 
-    echo fastqtools v0.8
-    echo ===============
-    echo the following commands are available:
-    ls -1 ${FASTQTOOLS_HOME}/bin
     echo
-    echo "Usage:"
-    echo "singularity run --app bioinformatics-fastqtools ${SINGULARITY_CONTAINER} <command>"
+    echo Program: fastqtools v0.8 (Tools for high throughput sequencing data in the FASTQ format)
+    echo Version: 0.8
+    echo
+    echo Usage: singularity run --app bioinformatics-fastqtools ${SINGULARITY_CONTAINER} <command>
+    echo
+    echo OR
+    echo        provided the fastqtools alias is defined as below:
+    echo        alias fastqtools="singularity run --app bioinformatics-fastqtools ${SINGULARITY_CONTAINER}"
+    echo
+    echo Usage: fastqtools <command>
+    echo
+    echo Commands:
+    echo     kmers
+    echo     match
+    echo     uniq
+    echo     qual
+    echo     sample
+    echo     qualaj
+    echo     qscale
     echo
 
 fi

--- a/_apps/bioinformatics/bioinformatics-samtools.md
+++ b/_apps/bioinformatics/bioinformatics-samtools.md
@@ -39,6 +39,10 @@ files:
     Samtools: Reading/writing/editing/indexing/viewing SAM/BAM/CRAM format
     BCFtools: Reading/writing BCF2/VCF/gVCF files and calling/filtering/summarising SNP and short indel sequence variants
     HTSlib: A C library for reading/writing high-throughput sequencing data
+    It is recommended to create the following alias:
+    alias samtools="singularity run --app bioinformatics-samtools \${SINGULARITY_CONTAINER}"
+    More help is then available by running
+    samtools --help
 %apprun bioinformatics-samtools
     samtools "$@"
 %applabels bioinformatics-samtools

--- a/_apps/bioinformatics/bioinformatics-samtools.md
+++ b/_apps/bioinformatics/bioinformatics-samtools.md
@@ -21,18 +21,18 @@ files:
     apt-get -y install autoconf libtool build-essential
     apt-get -y install zlibc libz-dev
     apt-get -y install libncurses5-dev
+    apt-get clean
     TARBZ2="samtools-1.3.1.tar.bz2"
     wget https://github.com/samtools/samtools/releases/download/1.3.1/${TARBZ2} -P ./
     tar -C ./ -xjf ./${TARBZ2}
     cd ./samtools-1.3.1
-    make
-    make prefix=../ install
+    make && make prefix=../ install
     cd -
     rm ./${TARBZ2}
     rm -rf ./samtools-1.3.1
 %appfiles bioinformatics-samtools
 %appenv bioinformatics-samtools
-    SAMTOOLS_HOME="/scif/apps/bioinformatics-samtools"
+    SAMTOOLS_HOME=/scif/apps/bioinformatics-samtools
     export SAMTOOLS_HOME
 %apphelp bioinformatics-samtools
     Samtools is a suite of programs for interacting with high-throughput sequencing data. It consists of three separate repositories:
@@ -43,7 +43,7 @@ files:
     samtools "$@"
 %applabels bioinformatics-samtools
     MAINTAINER adomissy@ucsd.edu
-    VERSION 0.0.1
-    WRAPPEDTOOL_VERSION: 1.3.0
-    WRAPPEDTOOL_INFO: "http://www.htslib.org/"
+    BUILD_VERSION 0.0.1
+    WRAPPEDTOOL_VERSION 1.3.0
+    WRAPPEDTOOL_INFO http://www.htslib.org/
 ```

--- a/_apps/bioinformatics/bioinformatics-samtools/SingularityApp.samtools
+++ b/_apps/bioinformatics/bioinformatics-samtools/SingularityApp.samtools
@@ -21,6 +21,10 @@
     Samtools: Reading/writing/editing/indexing/viewing SAM/BAM/CRAM format
     BCFtools: Reading/writing BCF2/VCF/gVCF files and calling/filtering/summarising SNP and short indel sequence variants
     HTSlib: A C library for reading/writing high-throughput sequencing data
+    It is recommended to create the following alias:
+    alias samtools="singularity run --app bioinformatics-samtools \${SINGULARITY_CONTAINER}"
+    More help is then available by running
+    samtools --help
 %apprun bioinformatics-samtools
     samtools "$@"
 %applabels bioinformatics-samtools

--- a/_apps/bioinformatics/bioinformatics-samtools/SingularityApp.samtools
+++ b/_apps/bioinformatics/bioinformatics-samtools/SingularityApp.samtools
@@ -3,18 +3,18 @@
     apt-get -y install autoconf libtool build-essential
     apt-get -y install zlibc libz-dev
     apt-get -y install libncurses5-dev
+    apt-get clean
     TARBZ2="samtools-1.3.1.tar.bz2"
     wget https://github.com/samtools/samtools/releases/download/1.3.1/${TARBZ2} -P ./
     tar -C ./ -xjf ./${TARBZ2}
     cd ./samtools-1.3.1
-    make
-    make prefix=../ install
+    make && make prefix=../ install
     cd -
     rm ./${TARBZ2}
     rm -rf ./samtools-1.3.1
 %appfiles bioinformatics-samtools
 %appenv bioinformatics-samtools
-    SAMTOOLS_HOME="${APPROOT_bioinformatics-samtools}""
+    SAMTOOLS_HOME=/scif/apps/bioinformatics-samtools
     export SAMTOOLS_HOME
 %apphelp bioinformatics-samtools
     Samtools is a suite of programs for interacting with high-throughput sequencing data. It consists of three separate repositories:
@@ -24,8 +24,7 @@
 %apprun bioinformatics-samtools
     samtools "$@"
 %applabels bioinformatics-samtools
-  MAINTAINER adomissy@ucsd.edu
-  VERSION 0.0.1
-  BUILD_DATE $(date -Ihours)
-  WRAPPEDTOOL_VERSION: 1.3.0
-  WRAPPEDTOOL_INFO: "http://www.htslib.org/"
+    MAINTAINER adomissy@ucsd.edu
+    BUILD_VERSION 0.0.1
+    WRAPPEDTOOL_VERSION 1.3.0
+    WRAPPEDTOOL_INFO http://www.htslib.org/


### PR DESCRIPTION
- this PR replaces completely PR #19, 
- better help and usage doc for fastqtools, 
- fully tested (with ubuntu 16.04 as the base) 
- local Jekyll was used to generate/download recipes:
  - for each separate tool 
  - as well as one recipe for the combination of both tools: fasqtools and samtools 
- those recipes were used to build squashfs images, 
- these simg's were tested and behaved as expected
